### PR TITLE
removed redundant calls to reload display state map

### DIFF
--- a/service/src/directory.js
+++ b/service/src/directory.js
@@ -14,14 +14,10 @@ const directoryClient = ds({
   apiKey: directoryApiKey,
 });
 
-// get a user's profile from the management API
+// get a user's profile from the directory API
 exports.getUser = async (_req, key) => {
   try {
     const user = await directoryClient.object({type: 'user', key: key});
-    const managerObject = await manager(user.key);
-    const userProps = user.properties.toJson();
-    userProps["manager"] = managerObject.key;
-    user.properties.fromJson(userProps);
     return user;
   } catch (error) {
     console.error(`getUser: caught exception: ${error}`);
@@ -69,31 +65,3 @@ exports.deleteUser = async (req, user) => {
   // not implemented
   return null;
 };
-
-// get an user's manager
-async function manager(userKey) {
-  try {
-    const relation = await directoryClient.relation({
-      subject: {
-        type: "user",
-        key: userKey,
-      },
-      object: {
-        type: "user",
-      },
-      relation: {
-        name: "manager",
-        objectType: "user",
-      },
-    });
-    if (!relation || relation.length === 0) {
-      throw new Error(`No relations found for user: ${userKey}`);
-    }
-
-    const manager = await directoryClient.object(relation[0].object);
-    return manager;
-  } catch (error) {
-    console.error(`manager: caught exception: ${error}`);
-    return null;
-  }
-}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { NavLink as RouterNavLink } from 'react-router-dom'
 
 import {
@@ -30,7 +30,7 @@ const NavBar = () => {
 
   const { signIn, signOut } = dexAuth
 
-  const { reload, identity, setIdentity } = useAserto();
+  const { identity, setIdentity } = useAserto();
   const { users } = useUsers();
 
   // set the current user by finding it in the user list based on the current identity

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -67,17 +67,7 @@ const NavBar = () => {
   // set the identity in the Aserto hook
   const setUser = (u) => {
     setIdentity(u);
-    // reload the display state if the user has not changed
-    if (u === identity) {
-      reload();
-    }
   }
-
-  // reload the display state map if the identity is changed
-  useEffect(() => {
-    reload();
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identity]);
 
   return (
     <div className="nav-container">

--- a/src/components/UserDetails.js
+++ b/src/components/UserDetails.js
@@ -45,7 +45,9 @@ const UserDetails = withRouter(({ user, setUser, loadUser, history }) => {
       setLoading(false);
     }
 
-    reloadDisplayStateMap();
+    if (user.key) {
+      reloadDisplayStateMap();
+    }
   }, [reload, user.key])
 
   useEffect(() => {


### PR DESCRIPTION
When testing the sample with a rebac policy, and switching users, I see a race condition where the displayStateMap is reloaded twice - once without a payload (by the NavBar code), and once from the UserDetails page (with a payload). When the call without a payload finishes later, the displayStateMap is hosed.

I also noticed that the perf of the sample is slower because `getUser` retrieves a manager relation and then the manager object, only to extract and store the exact same key that is already in `properties.manager`!  I removed this code and the performance is better.
